### PR TITLE
Fixed issue with seting id when data was present in EEPROM

### DIFF
--- a/Arduino/UUGear/UUGear.ino
+++ b/Arduino/UUGear/UUGear.ino
@@ -84,7 +84,7 @@ void(* resetDevice) (void) = 0;
 
 void setup() {
   // if has no id yet, generate one
-  if (getID() == "") {
+  if (getID().startsWith(ID_PREFIX) == false) {
     generateID();
   }
 


### PR DESCRIPTION
**What is the problem**
When the sketch is uploaded to a device with data already present in the EEPROM you can run into the issue where the getID will return some unknown string data. 

**What is the solution**
Make sure that the getID returns something that starts with the ID-prefix